### PR TITLE
Feat/6 store 등록 API 및 store 관련 기초 코드 작성

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-DB_USERNAME=postgres
-DB_PASSWORD=921003
-DB_NAME=basic_login

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+.env

--- a/src/main/kotlin/com/carava/carwash/auth/dto/SignUpRequestDto.kt
+++ b/src/main/kotlin/com/carava/carwash/auth/dto/SignUpRequestDto.kt
@@ -2,5 +2,6 @@ package com.carava.carwash.auth.dto
 
 data class SignUpRequestDto (
     val email: String,
-    val password: String
+    val password: String,
+    val name: String,
 )

--- a/src/main/kotlin/com/carava/carwash/auth/entity/Auth.kt
+++ b/src/main/kotlin/com/carava/carwash/auth/entity/Auth.kt
@@ -1,6 +1,7 @@
 package com.carava.carwash.auth.entity
 
 import com.carava.carwash.global.entity.BaseEntity
+import com.carava.carwash.member.entity.Member
 import jakarta.persistence.*
 
 @Entity(name = "auth")
@@ -15,4 +16,13 @@ class Auth (
 
     @Column(nullable = false)
     var password: String,
-) : BaseEntity()
+
+    @OneToOne(mappedBy = "auth")
+    var member: Member? = null,
+
+) : BaseEntity() {
+
+    fun getMemberId() : Long {
+        return member?.id ?: throw IllegalStateException("Auth에 연결된 Member가 없습니다.")
+    }
+}

--- a/src/main/kotlin/com/carava/carwash/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/carava/carwash/auth/service/AuthService.kt
@@ -3,27 +3,31 @@ package com.carava.carwash.auth.service
 import com.carava.carwash.auth.dto.*
 import com.carava.carwash.auth.entity.Auth
 import com.carava.carwash.global.config.security.JwtUtil
-import com.carava.carwash.global.constants.UserType
 import com.carava.carwash.global.dto.ApiResponse
 import com.carava.carwash.global.exception.EmailAlreadyExistsException
 import com.carava.carwash.auth.repository.AuthRepository
-import jakarta.transaction.Transactional
+import com.carava.carwash.member.dto.CreateMemberRequestDto
+import com.carava.carwash.member.service.MemberService
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.format.DateTimeFormatter
 
 @Service("authService")
-@Transactional
+@Transactional(readOnly = true)
 class AuthService(
     private val authRepository: AuthRepository,
+    private val memberService: MemberService,
+
     private val passwordEncoder: PasswordEncoder,
     private val jwtUtil: JwtUtil,
-    private val authenticationManager: AuthenticationManager
+    private val authenticationManager: AuthenticationManager,
 ) {
 
+    @Transactional
     fun signUp(request: SignUpRequestDto): ApiResponse<SignUpResponseDto> {
         if (authRepository.existsByEmail(request.email)) {
             throw EmailAlreadyExistsException("이미 존재하는 이메일입니다.")
@@ -33,8 +37,13 @@ class AuthService(
             email = request.email,
             password = passwordEncoder.encode(request.password)
         )
-
         val savedAuth = authRepository.save(auth)
+
+        val createMemberRequest = CreateMemberRequestDto(
+            name = request.name
+        )
+        val member = memberService.createMember(savedAuth, createMemberRequest)
+        savedAuth.member = member
 
         return ApiResponse.success(
             data = SignUpResponseDto(
@@ -53,7 +62,7 @@ class AuthService(
         val auth = authRepository.findByEmail(request.email)
             .orElseThrow{ UsernameNotFoundException("사용자를 찾을 수 없습니다.") }
 
-        val token = jwtUtil.generateToken(auth.email, UserType.OWNER)
+        val token = jwtUtil.generateToken(auth.email, auth.getMemberId())
 
         return ApiResponse.success(
             data = SignInResponseDto(

--- a/src/main/kotlin/com/carava/carwash/global/annotation/CurrentMemberId.kt
+++ b/src/main/kotlin/com/carava/carwash/global/annotation/CurrentMemberId.kt
@@ -1,0 +1,4 @@
+package com.carava.carwash.global.annotation
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class CurrentMemberId

--- a/src/main/kotlin/com/carava/carwash/global/config/WebConfig.kt
+++ b/src/main/kotlin/com/carava/carwash/global/config/WebConfig.kt
@@ -1,0 +1,15 @@
+package com.carava.carwash.global.config
+
+import com.carava.carwash.global.resolver.MemberIdResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig (
+    private val memberIdResolver: MemberIdResolver
+) : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(memberIdResolver)
+    }
+}

--- a/src/main/kotlin/com/carava/carwash/global/config/security/JwtUtil.kt
+++ b/src/main/kotlin/com/carava/carwash/global/config/security/JwtUtil.kt
@@ -1,6 +1,5 @@
 package com.carava.carwash.global.config.security
 
-import com.carava.carwash.global.constants.UserType
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
@@ -24,12 +23,13 @@ class JwtUtil {
         return Keys.hmacShaKeyFor(secretKey.toByteArray())
     }
 
-    fun generateToken(email: String, userType: UserType): String {
+    fun generateToken(email: String, memberId: Long): String {
         val now = Date()
         val expiryDate = Date(now.time + expiration)
 
         return Jwts.builder()
             .setSubject(email)
+            .claim("memberId", memberId)
             .setIssuedAt(now)
             .setExpiration(expiryDate)
             .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -38,6 +38,10 @@ class JwtUtil {
 
     fun getEmailFromToken(token: String): String {
         return getClaims(token).subject
+    }
+
+    fun getMemberIdFromToken(token: String): Long {
+        return (getClaims(token)["memberId"] as Number).toLong()
     }
 
     fun validateToken(token: String): Boolean {

--- a/src/main/kotlin/com/carava/carwash/global/resolver/MemberIdResolver.kt
+++ b/src/main/kotlin/com/carava/carwash/global/resolver/MemberIdResolver.kt
@@ -1,0 +1,30 @@
+package com.carava.carwash.global.resolver
+
+import com.carava.carwash.global.annotation.CurrentMemberId
+import com.carava.carwash.global.config.security.JwtUtil
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class MemberIdResolver(
+    private val jwtUtil: JwtUtil,
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter) =
+        parameter.hasParameterAnnotation(CurrentMemberId::class.java)
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Long {
+        val token = webRequest.getHeader("Authorization")?.removePrefix("Bearer ")
+            ?: throw IllegalArgumentException("Authorization 헤더가 없습니다.")
+        return jwtUtil.getMemberIdFromToken(token)
+    }
+}

--- a/src/main/kotlin/com/carava/carwash/member/dto/CreateMemberRequestDto.kt
+++ b/src/main/kotlin/com/carava/carwash/member/dto/CreateMemberRequestDto.kt
@@ -1,0 +1,5 @@
+package com.carava.carwash.member.dto
+
+data class CreateMemberRequestDto(
+    val name: String,
+)

--- a/src/main/kotlin/com/carava/carwash/member/entity/Member.kt
+++ b/src/main/kotlin/com/carava/carwash/member/entity/Member.kt
@@ -1,5 +1,6 @@
 package com.carava.carwash.member.entity
 
+import com.carava.carwash.auth.entity.Auth
 import com.carava.carwash.global.entity.BaseEntity
 import jakarta.persistence.*
 
@@ -10,9 +11,11 @@ class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0,
 
-    @Column(name = "owner_auth_id", nullable = false)
-    var authId: Long = 0,
-
     @Column(nullable = false)
     var name: String,
+
+    @OneToOne
+    @JoinColumn(name = "auth_id")
+    var auth: Auth,
+
 ) : BaseEntity()

--- a/src/main/kotlin/com/carava/carwash/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/carava/carwash/member/repository/MemberRepository.kt
@@ -1,0 +1,7 @@
+package com.carava.carwash.member.repository
+
+import com.carava.carwash.member.entity.Member
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository : JpaRepository<Member, Long> {
+}

--- a/src/main/kotlin/com/carava/carwash/member/service/MemberService.kt
+++ b/src/main/kotlin/com/carava/carwash/member/service/MemberService.kt
@@ -1,0 +1,27 @@
+package com.carava.carwash.member.service
+
+import com.carava.carwash.auth.entity.Auth
+import com.carava.carwash.member.dto.CreateMemberRequestDto
+import com.carava.carwash.member.entity.Member
+import com.carava.carwash.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service("memberService")
+@Transactional(readOnly = true)
+class MemberService(
+    private val memberRepository: MemberRepository
+) {
+
+    @Transactional
+    fun createMember(auth: Auth, request: CreateMemberRequestDto) : Member {
+        val member = Member(
+            name = request.name,
+            auth = auth
+        )
+
+        val savedMember = memberRepository.save(member)
+
+        return savedMember
+    }
+}

--- a/src/main/kotlin/com/carava/carwash/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/carava/carwash/store/controller/StoreController.kt
@@ -1,0 +1,29 @@
+package com.carava.carwash.store.controller
+
+import com.carava.carwash.global.annotation.CurrentMemberId
+import com.carava.carwash.global.dto.ApiResponse
+import com.carava.carwash.store.dto.CreateStoreRequestDto
+import com.carava.carwash.store.dto.CreateStoreResponseDto
+import com.carava.carwash.store.service.StoreService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("storeController")
+@RequestMapping("/api/stores")
+class StoreController(
+    private val storeService: StoreService,
+) {
+
+    @PostMapping
+    fun createStore(
+        @Valid @RequestBody request: CreateStoreRequestDto,
+        @CurrentMemberId memberId: Long,
+    ) : ApiResponse<CreateStoreResponseDto> {
+        val response = storeService.createStore(request, memberId)
+        return ApiResponse.success(data = response)
+    }
+
+}

--- a/src/main/kotlin/com/carava/carwash/store/dto/CreateStoreRequestDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/CreateStoreRequestDto.kt
@@ -1,0 +1,8 @@
+package com.carava.carwash.store.dto
+
+import com.carava.carwash.store.entity.StoreCategory
+
+data class CreateStoreRequestDto(
+    val name: String,
+    val category: StoreCategory
+)

--- a/src/main/kotlin/com/carava/carwash/store/dto/CreateStoreResponseDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/CreateStoreResponseDto.kt
@@ -1,0 +1,6 @@
+package com.carava.carwash.store.dto
+
+data class CreateStoreResponseDto(
+    val storeId: Long,
+    val createdAt: String,
+)

--- a/src/main/kotlin/com/carava/carwash/store/entity/Store.kt
+++ b/src/main/kotlin/com/carava/carwash/store/entity/Store.kt
@@ -1,0 +1,22 @@
+package com.carava.carwash.store.entity
+
+import com.carava.carwash.global.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity(name = "store")
+@Table(name = "store")
+class Store (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @Column(nullable = false)
+    var name: String,
+
+    @Column(nullable = false)
+    var ownerMemberId: Long = 0,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var category: StoreCategory = StoreCategory.CAR_WASH,
+) : BaseEntity()

--- a/src/main/kotlin/com/carava/carwash/store/entity/StoreCategory.kt
+++ b/src/main/kotlin/com/carava/carwash/store/entity/StoreCategory.kt
@@ -1,0 +1,5 @@
+package com.carava.carwash.store.entity
+
+enum class StoreCategory {
+    CAR_WASH, PPF_SHOP
+}

--- a/src/main/kotlin/com/carava/carwash/store/repositoty/StoreRepository.kt
+++ b/src/main/kotlin/com/carava/carwash/store/repositoty/StoreRepository.kt
@@ -1,0 +1,10 @@
+package com.carava.carwash.store.repositoty
+
+import com.carava.carwash.store.entity.Store
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository("storeRepository")
+interface StoreRepository : JpaRepository<Store, Long> {
+
+}

--- a/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
@@ -1,0 +1,32 @@
+package com.carava.carwash.store.service
+
+import com.carava.carwash.store.dto.CreateStoreRequestDto
+import com.carava.carwash.store.dto.CreateStoreResponseDto
+import com.carava.carwash.store.entity.Store
+import com.carava.carwash.store.repositoty.StoreRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.time.format.DateTimeFormatter
+
+@Service("storeService")
+@Transactional
+class StoreService(
+    private val storeRepository: StoreRepository
+) {
+
+    fun createStore(request: CreateStoreRequestDto, ownerMemberId: Long): CreateStoreResponseDto {
+
+        val store = Store(
+            name = request.name,
+            ownerMemberId = ownerMemberId,
+            category = request.category,
+        )
+        val savedStore = storeRepository.save(store)
+
+        return CreateStoreResponseDto(
+            storeId = savedStore.id,
+            createdAt = savedStore.createdAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        )
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    com.carava.carwash: DEBUG
+    org.springframework.web: DEBUG
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## 👍변경점

1. Store 관련 패키지와 코드가 추가되었습니다. 현재 Store은 필드로 id, name, ownerMemberId, category만을 가지고 있습니다.
2. Store을 등록하는 createStrore 메서드, API가 추가되었습니다.
3. Auth와 Member의 연관관계 설정
   + Auth와 Member 사이에 일대일 양방향 연관관계를 설정하였습니다.
   + 회원가입 요청시 Auth 객체 생성 후 Member 객체를 생성하도록 변경하였습니다.
4. @CurrentMemberId 어노테이션 구현
   + 요청을 보낸 사용자의 memberId를 알 수 있도록 @CurrentMemberId 어노테이션을 구현하였습니다.
   + 토큰 생성 시에 유저의 memberId를 추가, resolver에서 어노테이션 사용 시 memberId를 추출하도록 하였으며 설정파일을 통해 어노테이션을 등록하였습니다.
   + 파라미터에 어노테이션을 달아 사용할 수 있습니다.
5. 환경변수 파일을 트래킹하지 않도록 gitignore 파일을 수정하였습니다.
