### PR TITLE
Feat/12 Menu 등록 API, Menu 관련 기본 코드 작성

### DIFF
--- a/src/main/kotlin/com/carava/carwash/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/carava/carwash/auth/service/AuthService.kt
@@ -48,7 +48,7 @@ class AuthService(
         return ApiResponse.success(
             data = SignUpResponseDto(
                 email = savedAuth.email,
-                createdAt = savedAuth.createdAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                createdAt = savedAuth.createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
             )
         )
     }

--- a/src/main/kotlin/com/carava/carwash/global/exception/ForbiddenException.kt
+++ b/src/main/kotlin/com/carava/carwash/global/exception/ForbiddenException.kt
@@ -1,0 +1,4 @@
+package com.carava.carwash.global.exception
+
+class ForbiddenException(message: String) : RuntimeException(message) {
+}

--- a/src/main/kotlin/com/carava/carwash/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/carava/carwash/global/exception/GlobalExceptionHandler.kt
@@ -1,7 +1,6 @@
 package com.carava.carwash.global.exception
 
 import com.carava.carwash.global.dto.ApiResponse
-import org.apache.coyote.Response
 import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.userdetails.UsernameNotFoundException

--- a/src/main/kotlin/com/carava/carwash/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/carava/carwash/global/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.carava.carwash.global.exception
 
 import com.carava.carwash.global.dto.ApiResponse
+import org.apache.coyote.Response
 import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.userdetails.UsernameNotFoundException
@@ -26,6 +27,14 @@ class GlobalExceptionHandler {
     @ExceptionHandler(UsernameNotFoundException::class)
     fun handleUsernameNotFoundException(ex: UsernameNotFoundException) =
         ResponseEntity.badRequest().body(ApiResponse.error("USER_NOT_FOUND"))
+
+    @ExceptionHandler(ForbiddenException::class)
+    fun handleForbiddenException(ex: ForbiddenException) =
+        ResponseEntity.badRequest().body(ApiResponse.error("FORBIDDEN"))
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handlerNotFoundException(ex: NotFoundException) =
+        ResponseEntity.badRequest().body(ApiResponse.error("NOT_FOUND"))
 
     @ExceptionHandler(Exception::class)
     fun handleGenericException(ex: Exception) =

--- a/src/main/kotlin/com/carava/carwash/global/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/carava/carwash/global/exception/NotFoundException.kt
@@ -1,0 +1,4 @@
+package com.carava.carwash.global.exception
+
+class NotFoundException(message: String) : RuntimeException(message){
+}

--- a/src/main/kotlin/com/carava/carwash/menu/controller/MenuController.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/controller/MenuController.kt
@@ -6,7 +6,6 @@ import com.carava.carwash.menu.dto.CreateMenuRequestDto
 import com.carava.carwash.menu.dto.CreateMenuResponseDto
 import com.carava.carwash.menu.service.MenuService
 import jakarta.validation.Valid
-import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping

--- a/src/main/kotlin/com/carava/carwash/menu/controller/MenuController.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/controller/MenuController.kt
@@ -1,0 +1,30 @@
+package com.carava.carwash.menu.controller
+
+import com.carava.carwash.global.annotation.CurrentMemberId
+import com.carava.carwash.global.dto.ApiResponse
+import com.carava.carwash.menu.dto.CreateMenuRequestDto
+import com.carava.carwash.menu.dto.CreateMenuResponseDto
+import com.carava.carwash.menu.service.MenuService
+import jakarta.validation.Valid
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("menuController")
+@RequestMapping("/api/menus")
+class MenuController(
+    private val menuService: MenuService,
+) {
+
+    @PostMapping
+    fun createMenu(
+        @Valid @RequestBody request: CreateMenuRequestDto,
+        @CurrentMemberId memberId: Long,
+    ) : ApiResponse<CreateMenuResponseDto> {
+        val response = menuService.createMenu(request, memberId)
+        return ApiResponse.success(data = response)
+    }
+
+}

--- a/src/main/kotlin/com/carava/carwash/menu/dto/CreateMenuRequestDto.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/dto/CreateMenuRequestDto.kt
@@ -1,0 +1,9 @@
+package com.carava.carwash.menu.dto
+
+import java.math.BigDecimal
+
+data class CreateMenuRequestDto(
+    val storeId: Long,
+    val name: String,
+    val price: BigDecimal,
+)

--- a/src/main/kotlin/com/carava/carwash/menu/dto/CreateMenuResponseDto.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/dto/CreateMenuResponseDto.kt
@@ -1,0 +1,7 @@
+package com.carava.carwash.menu.dto
+
+data class CreateMenuResponseDto(
+    val menuId: Long,
+    val name: String,
+    val createdAt: String,
+)

--- a/src/main/kotlin/com/carava/carwash/menu/entity/Menu.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/entity/Menu.kt
@@ -1,0 +1,24 @@
+package com.carava.carwash.menu.entity
+
+import com.carava.carwash.global.entity.BaseEntity
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity(name = "menu")
+@Table(name = "menu")
+class Menu (
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @Column(nullable = false)
+    var name: String,
+
+    @Column(nullable = false)
+    var storeId: Long = 0,
+
+    @Column(nullable = false)
+    var price: BigDecimal,
+
+) : BaseEntity()

--- a/src/main/kotlin/com/carava/carwash/menu/repository/MenuRepository.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/repository/MenuRepository.kt
@@ -1,0 +1,9 @@
+package com.carava.carwash.menu.repository
+
+import com.carava.carwash.menu.entity.Menu
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository("menuRepository")
+interface MenuRepository : JpaRepository<Menu, Long> {
+}

--- a/src/main/kotlin/com/carava/carwash/menu/service/MenuService.kt
+++ b/src/main/kotlin/com/carava/carwash/menu/service/MenuService.kt
@@ -1,0 +1,39 @@
+package com.carava.carwash.menu.service
+
+import com.carava.carwash.menu.dto.CreateMenuRequestDto
+import com.carava.carwash.menu.dto.CreateMenuResponseDto
+import com.carava.carwash.menu.entity.Menu
+import com.carava.carwash.menu.repository.MenuRepository
+import com.carava.carwash.store.service.StoreService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.format.DateTimeFormatter
+
+@Service("menuService")
+@Transactional(readOnly = true)
+class MenuService(
+    private val menuRepository: MenuRepository,
+    private val storeService: StoreService,
+) {
+
+    @Transactional
+    fun createMenu(request: CreateMenuRequestDto, memberId: Long) : CreateMenuResponseDto {
+
+        storeService.validateStoreOwnership(request.storeId, memberId)
+
+        val menu = Menu(
+            storeId = request.storeId,
+            name = request.name,
+            price = request.price,
+        )
+        val savedMenu = menuRepository.save(menu)
+
+        return CreateMenuResponseDto(
+            menuId = savedMenu.id,
+            name = savedMenu.name,
+            createdAt = savedMenu.createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        )
+
+    }
+
+}

--- a/src/main/kotlin/com/carava/carwash/store/repositoty/StoreRepository.kt
+++ b/src/main/kotlin/com/carava/carwash/store/repositoty/StoreRepository.kt
@@ -3,8 +3,9 @@ package com.carava.carwash.store.repositoty
 import com.carava.carwash.store.entity.Store
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository("storeRepository")
 interface StoreRepository : JpaRepository<Store, Long> {
-
+    override fun findById(id: Long): Optional<Store>
 }

--- a/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
@@ -1,19 +1,22 @@
 package com.carava.carwash.store.service
 
+import com.carava.carwash.global.exception.ForbiddenException
+import com.carava.carwash.global.exception.NotFoundException
 import com.carava.carwash.store.dto.CreateStoreRequestDto
 import com.carava.carwash.store.dto.CreateStoreResponseDto
 import com.carava.carwash.store.entity.Store
 import com.carava.carwash.store.repositoty.StoreRepository
-import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.format.DateTimeFormatter
 
 @Service("storeService")
-@Transactional
+@Transactional(readOnly = true)
 class StoreService(
     private val storeRepository: StoreRepository
 ) {
 
+    @Transactional
     fun createStore(request: CreateStoreRequestDto, ownerMemberId: Long): CreateStoreResponseDto {
 
         val store = Store(
@@ -25,8 +28,18 @@ class StoreService(
 
         return CreateStoreResponseDto(
             storeId = savedStore.id,
-            createdAt = savedStore.createdAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            createdAt = savedStore.createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
         )
+    }
+
+    fun validateStoreOwnership(storeId: Long, ownerMemberId: Long) {
+        val store = storeRepository.findById(storeId)
+            .orElseThrow{ NotFoundException("가게를 찾을 수 없습니다.") }
+
+        if (store.ownerMemberId != ownerMemberId) {
+            throw ForbiddenException("해당 가게에 대한 권한이 없습니다.")
+        }
+
     }
 
 }


### PR DESCRIPTION
## 👍변경점

1. Menu 관련 패키지와 코드가 추가되었습니다. 현재 Menu는 필드로 id, name, storeId, price만을 가지고 있습니다.(Menu와 Store 사이에 연관관계 설정은 되어있지 않습니다.)
2. Menu를 등록하는 createMenu 메서드, API가 추가되었습니다.
3. StoreService의 validateStoreOwnership 메서드 추가 - createMenu 메서드가 호출되었을 때 호출한 유저가 해당 메뉴를 등록할 store의 주인이 맞는지 확인하도록 StoreService의 validateStoreOwnership 메서드를 호출합니다.
  storeId를 찾을 수 없으면 NotFoundException을, 주인이 아니라면 ForbiddenException을 호출합니다.(custom exception으로 global>exception 패키지에 추가되었습니다.)

