### PR TITLE
Feat/18 OperatingHour와 Holiday의 엔티티, 생성 API 구현

### DIFF
--- a/src/main/kotlin/com/carava/carwash/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/carava/carwash/store/controller/StoreController.kt
@@ -4,8 +4,12 @@ import com.carava.carwash.global.annotation.CurrentMemberId
 import com.carava.carwash.global.dto.ApiResponse
 import com.carava.carwash.store.dto.CreateStoreRequestDto
 import com.carava.carwash.store.dto.CreateStoreResponseDto
+import com.carava.carwash.store.dto.SaveOperatingHourRequestDto
+import com.carava.carwash.store.dto.SaveOperatingHourResponseDto
+import com.carava.carwash.store.service.OperatingHourService
 import com.carava.carwash.store.service.StoreService
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/stores")
 class StoreController(
     private val storeService: StoreService,
+    private val operatingHourService: OperatingHourService,
 ) {
 
     @PostMapping
@@ -23,6 +28,16 @@ class StoreController(
         @CurrentMemberId memberId: Long,
     ) : ApiResponse<CreateStoreResponseDto> {
         val response = storeService.createStore(request, memberId)
+        return ApiResponse.success(data = response)
+    }
+
+    @PostMapping("/{storeId}/operating-hours")
+    fun saveOperatingHours(
+        @PathVariable storeId: Long,
+        @RequestBody request: SaveOperatingHourRequestDto,
+        @CurrentMemberId memberId: Long
+    ) : ApiResponse<SaveOperatingHourResponseDto> {
+        val response = operatingHourService.saveOperatingHour(storeId, request, memberId)
         return ApiResponse.success(data = response)
     }
 

--- a/src/main/kotlin/com/carava/carwash/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/carava/carwash/store/controller/StoreController.kt
@@ -2,10 +2,8 @@ package com.carava.carwash.store.controller
 
 import com.carava.carwash.global.annotation.CurrentMemberId
 import com.carava.carwash.global.dto.ApiResponse
-import com.carava.carwash.store.dto.CreateStoreRequestDto
-import com.carava.carwash.store.dto.CreateStoreResponseDto
-import com.carava.carwash.store.dto.SaveOperatingHourRequestDto
-import com.carava.carwash.store.dto.SaveOperatingHourResponseDto
+import com.carava.carwash.store.dto.*
+import com.carava.carwash.store.service.HolidayService
 import com.carava.carwash.store.service.OperatingHourService
 import com.carava.carwash.store.service.StoreService
 import jakarta.validation.Valid
@@ -20,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 class StoreController(
     private val storeService: StoreService,
     private val operatingHourService: OperatingHourService,
+    private val holidayService: HolidayService,
 ) {
 
     @PostMapping
@@ -38,6 +37,16 @@ class StoreController(
         @CurrentMemberId memberId: Long
     ) : ApiResponse<SaveOperatingHourResponseDto> {
         val response = operatingHourService.saveOperatingHour(storeId, request, memberId)
+        return ApiResponse.success(data = response)
+    }
+
+    @PostMapping("/{storeId}/holidays")
+    fun createHoliday(
+        @PathVariable storeId: Long,
+        @RequestBody request: CreateHolidayRequestDto,
+        @CurrentMemberId memberId: Long
+    ) : ApiResponse<CreateHolidayResponseDto> {
+        val response = holidayService.createHoliday(storeId, request, memberId)
         return ApiResponse.success(data = response)
     }
 

--- a/src/main/kotlin/com/carava/carwash/store/dto/CreateHolidayRequestDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/CreateHolidayRequestDto.kt
@@ -1,0 +1,5 @@
+package com.carava.carwash.store.dto
+
+data class CreateHolidayRequestDto(
+    val holidays: List<HolidayDto>
+)

--- a/src/main/kotlin/com/carava/carwash/store/dto/CreateHolidayResponseDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/CreateHolidayResponseDto.kt
@@ -1,0 +1,7 @@
+package com.carava.carwash.store.dto
+
+import java.time.LocalDateTime
+
+data class CreateHolidayResponseDto(
+    val createdAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/carava/carwash/store/dto/HolidayDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/HolidayDto.kt
@@ -1,0 +1,7 @@
+package com.carava.carwash.store.dto
+
+import java.time.LocalDate
+
+data class HolidayDto(
+    val date: LocalDate,
+)

--- a/src/main/kotlin/com/carava/carwash/store/dto/OperatingHourDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/OperatingHourDto.kt
@@ -1,0 +1,11 @@
+package com.carava.carwash.store.dto
+
+import java.time.DayOfWeek
+import java.time.LocalTime
+
+data class OperatingHourDto(
+    val dayOfWeek: DayOfWeek,
+    val isOpen: Boolean,
+    val openTime: LocalTime?,
+    val closeTime: LocalTime?,
+)

--- a/src/main/kotlin/com/carava/carwash/store/dto/SaveOperatingHourRequestDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/SaveOperatingHourRequestDto.kt
@@ -1,0 +1,5 @@
+package com.carava.carwash.store.dto
+
+data class SaveOperatingHourRequestDto(
+    val operatingHours: List<OperatingHourDto>,
+)

--- a/src/main/kotlin/com/carava/carwash/store/dto/SaveOperatingHourResponseDto.kt
+++ b/src/main/kotlin/com/carava/carwash/store/dto/SaveOperatingHourResponseDto.kt
@@ -1,0 +1,7 @@
+package com.carava.carwash.store.dto
+
+import java.time.LocalDateTime
+
+data class SaveOperatingHourResponseDto(
+    val createdAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/carava/carwash/store/entity/Holiday.kt
+++ b/src/main/kotlin/com/carava/carwash/store/entity/Holiday.kt
@@ -1,0 +1,20 @@
+package com.carava.carwash.store.entity
+
+import com.carava.carwash.global.entity.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+@Table(name = "holiday")
+class Holiday (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    var store: Store,
+
+    var date: LocalDate,
+
+) : BaseEntity()

--- a/src/main/kotlin/com/carava/carwash/store/entity/OperatingHour.kt
+++ b/src/main/kotlin/com/carava/carwash/store/entity/OperatingHour.kt
@@ -1,0 +1,28 @@
+package com.carava.carwash.store.entity
+
+import com.carava.carwash.global.entity.BaseEntity
+import jakarta.persistence.*
+import java.time.DayOfWeek
+import java.time.LocalTime
+
+@Entity
+@Table(name = "operating_hours")
+class OperatingHour (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    var store: Store,
+
+    @Enumerated(EnumType.STRING)
+    var dayOfWeek: DayOfWeek,
+
+    var openTime: LocalTime?,
+
+    var closeTime: LocalTime?,
+
+    var isOpen: Boolean = true,
+
+) : BaseEntity()

--- a/src/main/kotlin/com/carava/carwash/store/entity/Store.kt
+++ b/src/main/kotlin/com/carava/carwash/store/entity/Store.kt
@@ -1,6 +1,7 @@
 package com.carava.carwash.store.entity
 
 import com.carava.carwash.global.entity.BaseEntity
+import com.carava.carwash.global.exception.ForbiddenException
 import jakarta.persistence.*
 
 @Entity(name = "store")
@@ -19,4 +20,12 @@ class Store (
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var category: StoreCategory = StoreCategory.CAR_WASH,
-) : BaseEntity()
+) : BaseEntity() {
+
+    fun validateOwnership(requestMemberId: Long) {
+        if (this.ownerMemberId != requestMemberId) {
+            throw ForbiddenException("해당 가게에 대한 권한이 없습니다.")
+        }
+    }
+
+}

--- a/src/main/kotlin/com/carava/carwash/store/repositoty/HolidayRepository.kt
+++ b/src/main/kotlin/com/carava/carwash/store/repositoty/HolidayRepository.kt
@@ -1,0 +1,7 @@
+package com.carava.carwash.store.repositoty
+
+import com.carava.carwash.store.entity.Holiday
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface HolidayRepository : JpaRepository<Holiday, Long> {
+}

--- a/src/main/kotlin/com/carava/carwash/store/repositoty/OperatingHourRepository.kt
+++ b/src/main/kotlin/com/carava/carwash/store/repositoty/OperatingHourRepository.kt
@@ -1,0 +1,9 @@
+package com.carava.carwash.store.repositoty
+
+import com.carava.carwash.store.entity.OperatingHour
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OperatingHourRepository : JpaRepository<OperatingHour, Long>{
+
+    fun deleteByStoreId(storeId: Long)
+}

--- a/src/main/kotlin/com/carava/carwash/store/service/HolidayService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/HolidayService.kt
@@ -1,0 +1,36 @@
+package com.carava.carwash.store.service
+
+import com.carava.carwash.store.dto.CreateHolidayRequestDto
+import com.carava.carwash.store.dto.CreateHolidayResponseDto
+import com.carava.carwash.store.entity.Holiday
+import com.carava.carwash.store.repositoty.HolidayRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service("holidayService")
+@Transactional(readOnly = true)
+class HolidayService (
+    val holidayRepository: HolidayRepository,
+    val storeService: StoreService,
+) {
+
+    @Transactional
+    fun createHoliday(storeId: Long, request: CreateHolidayRequestDto, memberId: Long) : CreateHolidayResponseDto{
+
+        val store = storeService.validateStoreOwnership(storeId, memberId)
+
+        val holidays = request.holidays.map { dto ->
+            Holiday(
+                store = store,
+                date = dto.date,
+            )
+        }
+
+        val savedHolidays = holidayRepository.saveAll(holidays)
+
+        return CreateHolidayResponseDto(
+            createdAt = savedHolidays.first().createdAt
+        )
+    }
+
+}

--- a/src/main/kotlin/com/carava/carwash/store/service/OperatingHourService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/OperatingHourService.kt
@@ -6,7 +6,6 @@ import com.carava.carwash.store.entity.OperatingHour
 import com.carava.carwash.store.repositoty.OperatingHourRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service("operatingHourService")
 @Transactional(readOnly = true)

--- a/src/main/kotlin/com/carava/carwash/store/service/OperatingHourService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/OperatingHourService.kt
@@ -1,0 +1,42 @@
+package com.carava.carwash.store.service
+
+import com.carava.carwash.store.dto.SaveOperatingHourRequestDto
+import com.carava.carwash.store.dto.SaveOperatingHourResponseDto
+import com.carava.carwash.store.entity.OperatingHour
+import com.carava.carwash.store.repositoty.OperatingHourRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service("operatingHourService")
+@Transactional(readOnly = true)
+class OperatingHourService(
+    private val operatingHourRepository: OperatingHourRepository,
+    private val storeService: StoreService,
+) {
+
+    @Transactional
+    fun saveOperatingHour(storeId: Long, request: SaveOperatingHourRequestDto, memberId: Long) : SaveOperatingHourResponseDto {
+
+        val store = storeService.validateStoreOwnership(storeId, memberId)
+
+        operatingHourRepository.deleteByStoreId(storeId)
+
+        val operatingHours = request.operatingHours.map { dto ->
+            OperatingHour(
+                store = store,
+                dayOfWeek = dto.dayOfWeek,
+                openTime = dto.openTime,
+                closeTime = dto.closeTime,
+                isOpen = dto.isOpen,
+            )
+        }
+
+        val savedOperatingHours = operatingHourRepository.saveAll(operatingHours)
+
+        return SaveOperatingHourResponseDto(
+            createdAt = savedOperatingHours.first().createdAt
+        )
+    }
+
+}

--- a/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
@@ -1,6 +1,5 @@
 package com.carava.carwash.store.service
 
-import com.carava.carwash.global.exception.ForbiddenException
 import com.carava.carwash.global.exception.NotFoundException
 import com.carava.carwash.store.dto.CreateStoreRequestDto
 import com.carava.carwash.store.dto.CreateStoreResponseDto

--- a/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
+++ b/src/main/kotlin/com/carava/carwash/store/service/StoreService.kt
@@ -31,14 +31,13 @@ class StoreService(
         )
     }
 
-    fun validateStoreOwnership(storeId: Long, ownerMemberId: Long) {
+    fun validateStoreOwnership(storeId: Long, ownerMemberId: Long): Store {
         val store = storeRepository.findById(storeId)
             .orElseThrow{ NotFoundException("가게를 찾을 수 없습니다.") }
 
-        if (store.ownerMemberId != ownerMemberId) {
-            throw ForbiddenException("해당 가게에 대한 권한이 없습니다.")
-        }
+        store.validateOwnership(ownerMemberId)
 
+        return store
     }
 
 }


### PR DESCRIPTION
## 👍변경점

### 1. OperatingHour(영업시간) 관리 기능 추가
- OperatingHour 엔티티 및 관련 패키지 추가
- Store와 OperatingHour 간 일대다 연관관계 설정
- `POST /api/stores/{storeId}/operating-hours` API 구현 / 요일별 영업시간 일괄 설정 (기존 데이터 삭제 후 재생성)

### 2. Holiday(휴무일) 관리 기능 추가  
- Holiday 엔티티 및 관련 패키지 추가
- Store와 Holiday 간 일대다 연관관계 설정
- `POST /api/stores/{storeId}/holidays` API 구현 / list로 요청을 받아 여러개의 휴무일을 한꺼번에 등록

### 3. 객체지향 설계 개선
- Store 소유권 검증 로직을 StoreService에서 Store 엔티티로 이동